### PR TITLE
perf(font): 精簡字體載入，移除未使用的 Inter 並限縮 Noto Sans TC 字重範圍

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -74,7 +74,7 @@ export default ({ mode }: { mode: string }) => {
     head: [
       ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
       ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: 'true' }],
-      ['link', { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;600;700;800;900&display=swap' }],
+      ['link', { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;600;800&display=swap' }],
       ['link', { rel: 'icon', href: '/favicon.ico' }],
 
     ],


### PR DESCRIPTION
700 與 900 可由瀏覽器從鄰近字重合成，減少 CJK 分片下載量