### PR TITLE
docs(blog-vue): 修正 Data Loader 文章標題「之」為「的」

### DIFF
--- a/content/blog-vue/260415.solve-fetch-waterfall-with-data-loader.md
+++ b/content/blog-vue/260415.solve-fetch-waterfall-with-data-loader.md
@@ -7,7 +7,7 @@ pubDate: 20260416
 
 ![solve-fetch-waterfall-with-data-loader](/solve-fetch-waterfall-with-data-loader.webp){.cover}
 
-# 用 Vue Router 之 Data Loader 解決 fetch 瀑布流問題
+# 用 Vue Router 的 Data Loader 解決 fetch 瀑布流問題
 
 <script setup>
 import { vueDataLoaderProject } from './solve-fetch-waterfall-with-data-loader/demo-project'
@@ -133,7 +133,7 @@ const [user, postList, commentList] = await Promise.all([
 
 有沒有辦法既讓元件獨立抓自己的資料，又同時做到平行載入呢？
 
-## Vue Router 之 Data Loader
+## Vue Router 的 Data Loader
 
 [Data Loader](https://router.vuejs.org/data-loaders/) 是 `unplugin-vue-router` 提供的功能，核心精神是**讓「資料請求」直接綁在元件上，由路由在跳轉頁面前統一提早觸發**。
 


### PR DESCRIPTION
「之」過於文言，改用口語化的「的」更符合寫作風格。