### PR TITLE
docs(blog-vue): 修正 Basic Loader 快取描述並補充 Colada Loader 說明

### DIFF
--- a/content/blog-vue/260415.solve-fetch-waterfall-with-data-loader.md
+++ b/content/blog-vue/260415.solve-fetch-waterfall-with-data-loader.md
@@ -203,11 +203,34 @@ export const useDashboardLoader = defineBasicLoader('/dashboard', async () => {
 })
 ```
 
-雖然從網路看依舊是瀑布流，但優勢在於**所有等待都集中在換頁前的「最頂層全局進度條」**。
+雖然從網路看依舊是瀑布流，但優勢在於所有等待都集中在換頁前的「最頂層全局進度條」，等畫面真正切換時資料已備齊，大幅減少版面跳動（Layout Shift）問題。
 
-畫面真正切換時，資料已備齊，可以大幅減少版面跳動（Layout Shift）問題。
+不過 Basic Loader 每次導航都會重新執行，沒有跨導航的快取機制。
 
-甚麼？你說叫後端濃縮成一支 API？成功的話，歡迎您分享分享溝通經驗。%(́⊙◞౪◟⊙‵)%
+::: tip 需要跨導航快取？試試 Colada Loader
+[Colada Loader](https://router.vuejs.org/data-loaders/colada/) 基於 `@pinia/colada`，除了保有平行載入的能力，還額外提供：
+
+- **快取**：透過 `staleTime` 控制資料新鮮度，期限內不重發請求
+- **去重複**：同一時間多處呼叫相同 Loader，只會發出一次請求
+
+```ts
+import { defineColadaLoader } from 'unplugin-vue-router/data-loaders/pinia-colada'
+
+export const useMeLoader = defineColadaLoader('/dashboard', {
+  key: () => ['me'],
+  async query() {
+    return fetchMe()
+  },
+  staleTime: 1000 * 60 * 5, // 5 分鐘內不重新請求
+})
+```
+
+即使多個 Loader 都需要 `fetchMe`，也只會發出一次請求，其餘直接拿快取，用過 TanStack Query 的朋友應該會覺得很熟悉。
+
+Colada Loader 也支援 SSR，在 Nuxt 上可以保證 Hydration 不會觸發額外的 fetch 操作。
+:::
+
+甚麼？你說叫後端濃縮成一支 API？成功的話，還請分享一下你抓到他什麼把柄。%(́⊙◞౪◟⊙‵)%
 
 ## 總結 🐟
 


### PR DESCRIPTION
原文誤將快取歸為 Basic Loader 特性，實際上跨導航快取與去重複
屬於 Colada Loader，以 tip 區塊補充說明。