### PR TITLE
fix(meme-cache): 抽離 BlurLevel enum 避免 sharp 被打包進 client

### DIFF
--- a/.vitepress/utils/blur-estimator.test.ts
+++ b/.vitepress/utils/blur-estimator.test.ts
@@ -1,7 +1,8 @@
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { BlurLevel, computeBlurLevel } from './blur-estimator'
+import { BlurLevel } from './blur-level'
+import { computeBlurLevel } from './blur-estimator'
 
 const currentDir = path.dirname(fileURLToPath(import.meta.url))
 const MEME_DIR = path.resolve(currentDir, '../../content/public/memes')

--- a/.vitepress/utils/blur-estimator.ts
+++ b/.vitepress/utils/blur-estimator.ts
@@ -1,15 +1,6 @@
 import type { Buffer } from 'node:buffer'
 import sharp from 'sharp'
-
-/** 圖片模糊等級，分成 3 級 */
-export enum BlurLevel {
-  /** 清晰 */
-  LEVEL_0,
-  /** 稍微模糊 */
-  LEVEL_1,
-  /** 非常模糊 */
-  LEVEL_2,
-}
+import { BlurLevel } from './blur-level'
 
 const RESIZE_TARGET = 200
 const EDGE_THRESHOLD = 25

--- a/.vitepress/utils/blur-level.ts
+++ b/.vitepress/utils/blur-level.ts
@@ -1,0 +1,9 @@
+/** 圖片模糊等級，分成 3 級 */
+export enum BlurLevel {
+  /** 清晰 */
+  LEVEL_0,
+  /** 稍微模糊 */
+  LEVEL_1,
+  /** 非常模糊 */
+  LEVEL_2,
+}

--- a/content/aquarium/meme-cache/type.ts
+++ b/content/aquarium/meme-cache/type.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { BlurLevel } from '../../../.vitepress/utils/blur-estimator'
+import { BlurLevel } from '../../../.vitepress/utils/blur-level'
 
 export const memeDataSchema = z.object({
   file: z.string(),


### PR DESCRIPTION
type.ts 透過 blur-estimator 間接引入 sharp，導致正式環境 chunk 執行 process.platform 時報 ReferenceError。將 enum 獨立為 blur-level.ts，切斷 client 對 Node 模組的依賴。